### PR TITLE
Cleanup WASM Interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,13 @@ CFLAGS += --target=wasm32-unknown-wasi -Wall -g -Os
 # Details on a few of the linker flags used:
 #
 #   -Wl,  <-- needed to pass the immediately following option directly to the linker,
-#   --export-dynamic  <-- have linker export all non-hidden symbols, see https://lld.llvm.org/WebAssembly.html#cmdoption-export-dynamic
-#   --import-undefined  <-- produce a WebAssembly import for any undefined symbols, where possible, see https://lld.llvm.org/WebAssembly.html#cmdoption-import-undefined
-LDFLAGS += -Wl,--export-dynamic -Wl,--import-undefined
+#   --export-dynamic  <-- have linker export all non-hidden symbols
+#       see https://lld.llvm.org/WebAssembly.html#cmdoption-export-dynamic
+#   --import-undefined  <-- produce a WebAssembly import for any undefined symbols, where possible
+#       see https://lld.llvm.org/WebAssembly.html#cmdoption-import-undefined
+#   -mexec-model=reactor  <-- says "this isn't a command/program with a 'main' function that drives its execution, instead this is a library with a lifetime controlled by the user",
+#       see https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-mexec-model
+LDFLAGS += -Wl,--export-dynamic -Wl,--import-undefined -mexec-model=reactor
 LIBS += -lm -lc
 
 OUTPUT_DIR = build

--- a/doom.wasm.interface.txt
+++ b/doom.wasm.interface.txt
@@ -31,7 +31,7 @@ imports:
 
 exports:
   function _initialize()
-  function initGame(i32, i32)
+  function initGame()
   function reportKeyDown(i32)
   function reportKeyUp(i32)
   function tickGame()

--- a/doom.wasm.interface.txt
+++ b/doom.wasm.interface.txt
@@ -8,13 +8,13 @@
 ##############################################################################
 
 imports:
-  function env.DG_DrawFrame()
-  function env.DG_GetKey(i32, i32)
-  function env.DG_GetTicksMs()
-  function env.DG_Init()
-  function env.DG_SetWindowTitle(i32)
-  function env.DG_SleepMs(i32)
   function env.W_ParseCommandLine()
+  function runtimeControl.getTicksMs()
+  function runtimeControl.sleepMs(i32)
+  function ui.drawFrame()
+  function ui.getKey(i32, i32)
+  function ui.onGameInit()
+  function ui.setWindowTitle(i32)
   function wasi_snapshot_preview1.fd_close(i32)
   function wasi_snapshot_preview1.fd_fdstat_get(i32, i32)
   function wasi_snapshot_preview1.fd_fdstat_set_flags(i32, i32)

--- a/doom.wasm.interface.txt
+++ b/doom.wasm.interface.txt
@@ -12,7 +12,6 @@ imports:
   function runtimeControl.getTicksMs()
   function runtimeControl.sleepMs(i32)
   function ui.drawFrame(i32)
-  function ui.getKey(i32, i32)
   function ui.onGameInit(i32, i32)
   function ui.setWindowTitle(i32)
   function wasi_snapshot_preview1.fd_close(i32)
@@ -33,5 +32,7 @@ imports:
 exports:
   function _initialize()
   function initGame(i32, i32)
+  function reportKeyDown(i32)
+  function reportKeyUp(i32)
   function tickGame()
   memory memory(min = 8, max = ∞)

--- a/doom.wasm.interface.txt
+++ b/doom.wasm.interface.txt
@@ -15,7 +15,6 @@ imports:
   function env.DG_SetWindowTitle(i32)
   function env.DG_SleepMs(i32)
   function env.W_ParseCommandLine()
-  function env.system(i32)
   function wasi_snapshot_preview1.fd_close(i32)
   function wasi_snapshot_preview1.fd_fdstat_get(i32, i32)
   function wasi_snapshot_preview1.fd_fdstat_set_flags(i32, i32)

--- a/doom.wasm.interface.txt
+++ b/doom.wasm.interface.txt
@@ -13,7 +13,7 @@ imports:
   function runtimeControl.sleepMs(i32)
   function ui.drawFrame(i32)
   function ui.getKey(i32, i32)
-  function ui.onGameInit()
+  function ui.onGameInit(i32, i32)
   function ui.setWindowTitle(i32)
   function wasi_snapshot_preview1.fd_close(i32)
   function wasi_snapshot_preview1.fd_fdstat_get(i32, i32)

--- a/doom.wasm.interface.txt
+++ b/doom.wasm.interface.txt
@@ -16,8 +16,6 @@ imports:
   function env.DG_SleepMs(i32)
   function env.W_ParseCommandLine()
   function env.system(i32)
-  function wasi_snapshot_preview1.args_get(i32, i32)
-  function wasi_snapshot_preview1.args_sizes_get(i32, i32)
   function wasi_snapshot_preview1.fd_close(i32)
   function wasi_snapshot_preview1.fd_fdstat_get(i32, i32)
   function wasi_snapshot_preview1.fd_fdstat_set_flags(i32, i32)
@@ -34,7 +32,7 @@ imports:
   function wasi_snapshot_preview1.proc_exit(i32)
 
 exports:
-  function _start()
+  function _initialize()
   function initGame(i32, i32)
   function tickGame()
   memory memory(min = 8, max = ∞)

--- a/doom.wasm.interface.txt
+++ b/doom.wasm.interface.txt
@@ -11,7 +11,7 @@ imports:
   function env.W_ParseCommandLine()
   function runtimeControl.getTicksMs()
   function runtimeControl.sleepMs(i32)
-  function ui.drawFrame()
+  function ui.drawFrame(i32)
   function ui.getKey(i32, i32)
   function ui.onGameInit()
   function ui.setWindowTitle(i32)

--- a/src/doom_wasm.c
+++ b/src/doom_wasm.c
@@ -1,5 +1,7 @@
 #include "doomgeneric.h"
 
+#include <stdbool.h>
+
 /*
  * This file provides augmentations to the interface (i.e. imports and exports)
  * that is produced when Doom is compiled to a WebAssembly module.
@@ -11,8 +13,6 @@
 
 __attribute__((import_module("ui"))) void onGameInit(int width, int height);
 __attribute__((import_module("ui"))) void drawFrame(uint32_t *screenBuffer);
-__attribute__((import_module("ui"))) int getKey(int *pressed,
-                                                unsigned char *key);
 __attribute__((import_module("ui"))) void setWindowTitle(const char *title);
 
 __attribute__((import_module("runtimeControl"))) void sleepMs(uint32_t ms);
@@ -22,11 +22,24 @@ __attribute__((import_module("runtimeControl"))) uint32_t getTicksMs();
 // *                             EXPORTED FUNCTIONS                            *
 // *****************************************************************************
 
+// A global cache of which keys are currently pressed down, according to what
+// the user of this module has reported to via `reportKeyDown` and
+// `reportKeyUp`.
+static bool isKeyPressed[UINT8_MAX] = {false};
+
 __attribute__((visibility("default"))) void initGame(int argc, char **argv) {
   doomgeneric_Create(argc, argv);
 }
 
 __attribute__((visibility("default"))) void tickGame() { doomgeneric_Tick(); }
+
+__attribute__((visibility("default"))) void reportKeyDown(uint8_t doomKey) {
+  isKeyPressed[doomKey] = true;
+}
+
+__attribute__((visibility("default"))) void reportKeyUp(uint8_t doomKey) {
+  isKeyPressed[doomKey] = false;
+}
 
 // *****************************************************************************
 // *                           IMPLEMENTATION DETAILS                          *
@@ -39,7 +52,26 @@ void DG_Init() { onGameInit(DOOMGENERIC_RESX, DOOMGENERIC_RESY); }
 
 void DG_DrawFrame() { drawFrame(DG_ScreenBuffer); }
 
-int DG_GetKey(int *pressed, unsigned char *key) { return getKey(pressed, key); }
+int DG_GetKey(int *pressed, uint8_t *doomKey) {
+  // Keep a cache of what the last communicated state of each key was, so that
+  // each time the Doom engine calls this function we're prepared to relay any
+  // key state changes that have been reported since the last call to this
+  // function. By default all the keys start in the "not pressed" state.
+  static bool statePreviouslyCommunicated[UINT8_MAX] = {false};
+
+  for (int i = 0; i < UINT8_MAX; i++) {
+    // If the actual state of this key doesn't match the last communicated state
+    if (isKeyPressed[i] != statePreviouslyCommunicated[i]) {
+      *pressed = isKeyPressed[i];
+      *doomKey = i;
+      // We're communicating this key state change, so update the cache of the
+      // last communicated state of this key.
+      statePreviouslyCommunicated[i] = isKeyPressed[i];
+      return 1;
+    }
+  }
+  return 0;
+}
 
 void DG_SetWindowTitle(const char *title) { setWindowTitle(title); }
 

--- a/src/doom_wasm.c
+++ b/src/doom_wasm.c
@@ -9,7 +9,7 @@
 // *                             IMPORTED FUNCTIONS                            *
 // *****************************************************************************
 
-__attribute__((import_module("ui"))) void onGameInit();
+__attribute__((import_module("ui"))) void onGameInit(int width, int height);
 __attribute__((import_module("ui"))) void drawFrame(uint32_t *screenBuffer);
 __attribute__((import_module("ui"))) int getKey(int *pressed,
                                                 unsigned char *key);
@@ -35,7 +35,7 @@ __attribute__((visibility("default"))) void tickGame() { doomgeneric_Tick(); }
 // Here we implement the doomgeneric interface via the functions imported via
 // WebAssembly imports.
 
-void DG_Init() { onGameInit(); }
+void DG_Init() { onGameInit(DOOMGENERIC_RESX, DOOMGENERIC_RESY); }
 
 void DG_DrawFrame() { drawFrame(DG_ScreenBuffer); }
 

--- a/src/doom_wasm.c
+++ b/src/doom_wasm.c
@@ -22,7 +22,7 @@ __attribute__((import_module("runtimeControl"))) uint32_t getTicksMs();
 // *                             EXPORTED FUNCTIONS                            *
 // *****************************************************************************
 
-__attribute__((visibility("default"))) void initGame(int argc, char **argv);
+__attribute__((visibility("default"))) void initGame();
 __attribute__((visibility("default"))) void tickGame();
 __attribute__((visibility("default"))) void reportKeyDown(uint8_t doomKey);
 __attribute__((visibility("default"))) void reportKeyUp(uint8_t doomKey);
@@ -77,7 +77,16 @@ uint32_t DG_GetTicksMs() { return getTicksMs(); }
 // functions.
 ////////////////////////////////////////////////////////////////////////////////
 
-void initGame(int argc, char **argv) { doomgeneric_Create(argc, argv); }
+void initGame() {
+  // Provide 0 command line arguments to Doom.
+  // Any configuration knobs we end up exposing via WebAssembly that would
+  // usually be handled by command line arguments will instead be handled in a
+  // different way.
+  int argc = 0;
+  char *argv[] = {};
+
+  doomgeneric_Create(argc, argv);
+}
 
 void tickGame() { doomgeneric_Tick(); }
 

--- a/src/doom_wasm.c
+++ b/src/doom_wasm.c
@@ -5,8 +5,44 @@
  * that is produced when Doom is compiled to a WebAssembly module.
  */
 
+// *****************************************************************************
+// *                             IMPORTED FUNCTIONS                            *
+// *****************************************************************************
+
+__attribute__((import_module("ui"))) void onGameInit();
+__attribute__((import_module("ui"))) void drawFrame();
+__attribute__((import_module("ui"))) int getKey(int *pressed,
+                                                unsigned char *key);
+__attribute__((import_module("ui"))) void setWindowTitle(const char *title);
+
+__attribute__((import_module("runtimeControl"))) void sleepMs(uint32_t ms);
+__attribute__((import_module("runtimeControl"))) uint32_t getTicksMs();
+
+// *****************************************************************************
+// *                             EXPORTED FUNCTIONS                            *
+// *****************************************************************************
+
 __attribute__((visibility("default"))) void initGame(int argc, char **argv) {
   doomgeneric_Create(argc, argv);
 }
 
 __attribute__((visibility("default"))) void tickGame() { doomgeneric_Tick(); }
+
+// *****************************************************************************
+// *                           IMPLEMENTATION DETAILS                          *
+// *****************************************************************************
+
+// Here we implement the doomgeneric interface via the functions imported via
+// WebAssembly imports.
+
+void DG_Init() { onGameInit(); }
+
+void DG_DrawFrame() { drawFrame(); }
+
+int DG_GetKey(int *pressed, unsigned char *key) { return getKey(pressed, key); }
+
+void DG_SetWindowTitle(const char *title) { setWindowTitle(title); }
+
+void DG_SleepMs(uint32_t ms) { sleepMs(ms); }
+
+uint32_t DG_GetTicksMs() { return getTicksMs(); }

--- a/src/doom_wasm.c
+++ b/src/doom_wasm.c
@@ -10,7 +10,7 @@
 // *****************************************************************************
 
 __attribute__((import_module("ui"))) void onGameInit();
-__attribute__((import_module("ui"))) void drawFrame();
+__attribute__((import_module("ui"))) void drawFrame(uint32_t *screenBuffer);
 __attribute__((import_module("ui"))) int getKey(int *pressed,
                                                 unsigned char *key);
 __attribute__((import_module("ui"))) void setWindowTitle(const char *title);
@@ -37,7 +37,7 @@ __attribute__((visibility("default"))) void tickGame() { doomgeneric_Tick(); }
 
 void DG_Init() { onGameInit(); }
 
-void DG_DrawFrame() { drawFrame(); }
+void DG_DrawFrame() { drawFrame(DG_ScreenBuffer); }
 
 int DG_GetKey(int *pressed, unsigned char *key) { return getKey(pressed, key); }
 

--- a/src/doom_wasm.c
+++ b/src/doom_wasm.c
@@ -22,31 +22,24 @@ __attribute__((import_module("runtimeControl"))) uint32_t getTicksMs();
 // *                             EXPORTED FUNCTIONS                            *
 // *****************************************************************************
 
-// A global cache of which keys are currently pressed down, according to what
-// the user of this module has reported to via `reportKeyDown` and
-// `reportKeyUp`.
-static bool isKeyPressed[UINT8_MAX] = {false};
-
-__attribute__((visibility("default"))) void initGame(int argc, char **argv) {
-  doomgeneric_Create(argc, argv);
-}
-
-__attribute__((visibility("default"))) void tickGame() { doomgeneric_Tick(); }
-
-__attribute__((visibility("default"))) void reportKeyDown(uint8_t doomKey) {
-  isKeyPressed[doomKey] = true;
-}
-
-__attribute__((visibility("default"))) void reportKeyUp(uint8_t doomKey) {
-  isKeyPressed[doomKey] = false;
-}
+__attribute__((visibility("default"))) void initGame(int argc, char **argv);
+__attribute__((visibility("default"))) void tickGame();
+__attribute__((visibility("default"))) void reportKeyDown(uint8_t doomKey);
+__attribute__((visibility("default"))) void reportKeyUp(uint8_t doomKey);
 
 // *****************************************************************************
 // *                           IMPLEMENTATION DETAILS                          *
 // *****************************************************************************
 
+// A global cache of which keys are currently pressed down, according to what
+// the user of this module has reported to via `reportKeyDown` and
+// `reportKeyUp`.
+static bool isKeyPressed[UINT8_MAX] = {false};
+
+////////////////////////////////////////////////////////////////////////////////
 // Here we implement the doomgeneric interface via the functions imported via
 // WebAssembly imports.
+////////////////////////////////////////////////////////////////////////////////
 
 void DG_Init() { onGameInit(DOOMGENERIC_RESX, DOOMGENERIC_RESY); }
 
@@ -78,3 +71,16 @@ void DG_SetWindowTitle(const char *title) { setWindowTitle(title); }
 void DG_SleepMs(uint32_t ms) { sleepMs(ms); }
 
 uint32_t DG_GetTicksMs() { return getTicksMs(); }
+
+////////////////////////////////////////////////////////////////////////////////
+// Here we implement, via the doomgeneric interface, the WebAssembly exported
+// functions.
+////////////////////////////////////////////////////////////////////////////////
+
+void initGame(int argc, char **argv) { doomgeneric_Create(argc, argv); }
+
+void tickGame() { doomgeneric_Tick(); }
+
+void reportKeyDown(uint8_t doomKey) { isKeyPressed[doomKey] = true; }
+
+void reportKeyUp(uint8_t doomKey) { isKeyPressed[doomKey] = false; }

--- a/src/i_system.c
+++ b/src/i_system.c
@@ -243,85 +243,6 @@ void I_Quit(void) {
 #endif
 }
 
-#if !defined(_WIN32) && !defined(__MACOSX__)
-#define ZENITY_BINARY "/usr/bin/zenity"
-
-// returns non-zero if zenity is available
-
-static int ZenityAvailable(void) {
-  return system(ZENITY_BINARY " --help >/dev/null 2>&1") == 0;
-}
-
-// Escape special characters in the given string so that they can be
-// safely enclosed in shell quotes.
-
-static char *EscapeShellString(char *string) {
-  char *result;
-  char *r, *s;
-
-  // In the worst case, every character might be escaped.
-  result = malloc(strlen(string) * 2 + 3);
-  r = result;
-
-  // Enclosing quotes.
-  *r = '"';
-  ++r;
-
-  for (s = string; *s != '\0'; ++s) {
-    // From the bash manual:
-    //
-    //  "Enclosing characters in double quotes preserves the literal
-    //   value of all characters within the quotes, with the exception
-    //   of $, `, \, and, when history expansion is enabled, !."
-    //
-    // Therefore, escape these characters by prefixing with a backslash.
-
-    if (strchr("$`\\!", *s) != NULL) {
-      *r = '\\';
-      ++r;
-    }
-
-    *r = *s;
-    ++r;
-  }
-
-  // Enclosing quotes.
-  *r = '"';
-  ++r;
-  *r = '\0';
-
-  return result;
-}
-
-// Open a native error box with a message using zenity
-
-static int ZenityErrorBox(char *message) {
-  int result;
-  char *escaped_message;
-  char *errorboxpath;
-  static size_t errorboxpath_size;
-
-  if (!ZenityAvailable()) {
-    return 0;
-  }
-
-  escaped_message = EscapeShellString(message);
-
-  errorboxpath_size = strlen(ZENITY_BINARY) + strlen(escaped_message) + 19;
-  errorboxpath = malloc(errorboxpath_size);
-  M_snprintf(errorboxpath, errorboxpath_size, "%s --error --text=%s",
-             ZENITY_BINARY, escaped_message);
-
-  result = system(errorboxpath);
-
-  free(errorboxpath);
-  free(escaped_message);
-
-  return result;
-}
-
-#endif /* !defined(_WIN32) && !defined(__MACOSX__) */
-
 //
 // I_Error
 //
@@ -329,10 +250,8 @@ static int ZenityErrorBox(char *message) {
 static boolean already_quitting = false;
 
 void I_Error(char *error, ...) {
-  char msgbuf[512];
   va_list argptr;
   atexit_listentry_t *entry;
-  boolean exit_gui_popup;
 
   if (already_quitting) {
     fprintf(stderr, "Warning: recursive call to I_Error detected.\n");
@@ -351,12 +270,6 @@ void I_Error(char *error, ...) {
   va_end(argptr);
   fflush(stderr);
 
-  // Write a copy of the message into buffer.
-  va_start(argptr, error);
-  memset(msgbuf, 0, sizeof(msgbuf));
-  M_vsnprintf(msgbuf, sizeof(msgbuf), error, argptr);
-  va_end(argptr);
-
   // Shutdown. Here might be other errors.
 
   entry = exit_funcs;
@@ -368,48 +281,6 @@ void I_Error(char *error, ...) {
 
     entry = entry->next;
   }
-
-  exit_gui_popup = !M_ParmExists("-nogui");
-
-  // Pop up a GUI dialog box to show the error message, if the
-  // game was not run from the console (and the user will
-  // therefore be unable to otherwise see the message).
-  if (exit_gui_popup && !I_ConsoleStdout())
-#ifdef _WIN32
-  {
-    wchar_t wmsgbuf[512];
-
-    MultiByteToWideChar(CP_ACP, 0, msgbuf, strlen(msgbuf) + 1, wmsgbuf,
-                        sizeof(wmsgbuf));
-
-    MessageBoxW(NULL, wmsgbuf, L"", MB_OK);
-  }
-#elif defined(__MACOSX__)
-  {
-    CFStringRef message;
-    int i;
-
-    // The CoreFoundation message box wraps text lines, so replace
-    // newline characters with spaces so that multiline messages
-    // are continuous.
-
-    for (i = 0; msgbuf[i] != '\0'; ++i) {
-      if (msgbuf[i] == '\n') {
-        msgbuf[i] = ' ';
-      }
-    }
-
-    message = CFStringCreateWithCString(NULL, msgbuf, kCFStringEncodingUTF8);
-
-    CFUserNotificationDisplayNotice(0, kCFUserNotificationCautionAlertLevel,
-                                    NULL, NULL, NULL, CFSTR(PACKAGE_STRING),
-                                    message, NULL);
-  }
-#else
-  {
-    ZenityErrorBox(msgbuf);
-  }
-#endif
 
   // abort();
 #if ORIGCODE


### PR DESCRIPTION
# What's motivating this work?

The WebAssembly interface provided by `doom.wasm` (i.e. the module's imports and exports) isn't actually usable yet.

Here we're making a first pass at improving this interface.

After these changes the WebAssembly module still won't be usable, but it's much closer to being usable! The issues that remain after these changes are much larger ones that'll each be addressed separately in the future.

# What specifically is being done?

These specific pain points are being addressed:
- A function `env.system` is being imported, which is used by _Doom_ to execute a shell command via name
  - [Fix](https://github.com/jacobenget/doom.wasm/commit/4fcafe5d0e4dd1cacff59accde8d33cc9c3a16b6): the need for calling `env.system` (creating a native GUI for error reporting) has been removed from the source code
- WASI functions related to handling command-line args are being imported
  - [Fix](https://github.com/jacobenget/doom.wasm/commit/893f09b4ee8339a8c7d491bbff918a8b593706ee): we switch to using the [WebAssembly-specific 'reactor' executable model](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-mexec-model), which removes our dependency on these functions
- The _Doom_-specific imported functions all have a module of `env` and a name that begins with `DG_` (due to being a function in the `doomgeneric` interface)
  - [Fix](https://github.com/jacobenget/doom.wasm/commit/8c5356f4cf3d9b7b499bba1288e8859050507c8f): provide more descriptive per-function module identifiers, and rename the functions to remove associates with `doomgeneric`
- Imported functions do not have access to important global constants and variables (i.e. pointer to frame buffer, width and height of frame buffer) that are available to C code
  - Fix ([here](https://github.com/jacobenget/doom.wasm/commit/c88f5c2aa9c89f800f0bcc2ec7ddfad9ccea9d5a) and [here](https://github.com/jacobenget/doom.wasm/commit/0bb692724981a2f1b65417c88a7d765adac65b0f)): provide these values directly to the related imported functions. Provide the frame buffer width and height to `ui.onGameInit`, and provide a pointer to the frame buffer to `ui.drawFrame`
- The exported function `initGame` expects the user to pass in details related to command-line arguments, which a user of a WebAssembly module doesn't really have a good way of providing (without a way to dynamically allocate space for C strings in the `memory` used by the module, which we're not supporting at the moment)
  - [Fix](https://github.com/jacobenget/doom.wasm/commit/c4fe4f47c8399811a52721bcb7646aa4424c6e04): make it so `initGame` doesn't require these details, and instead fabricates 'empty command-line args' itself to pass to _Doom_
- User is expected to report the state of key presses asynchronously to _Doom_ (by implementing the imported function `ui.getKey` that reports changes in key pressed whenever called), which may require managing the state of all key presses so _Doom_ can query them whenever it feels like
  - [Fix](https://github.com/jacobenget/doom.wasm/commit/d685d94165f016276a595418c6877598ed242475): make it so the user can instead call an exported function or two (`reportKeyDown` and `reportKeyUp`) whenever the press state of a key changes, which will be much easier to manage for the user