### PR TITLE
Support Game Saving

### DIFF
--- a/doom.wasm.interface.txt
+++ b/doom.wasm.interface.txt
@@ -8,8 +8,9 @@
 ##############################################################################
 
 imports:
-  function env.DG_OpenSaveGameReader(i32)
-  function env.DG_OpenSaveGameWriter(i32)
+  function gameSaving.readSaveGame(i32, i32)
+  function gameSaving.sizeOfSaveGame(i32)
+  function gameSaving.writeSaveGame(i32, i32, i32)
   function loading.getWadsSizes(i32, i32)
   function loading.readDataForAllWads(i32, i32)
   function runtimeControl.getTicksMs()

--- a/doom.wasm.interface.txt
+++ b/doom.wasm.interface.txt
@@ -8,6 +8,8 @@
 ##############################################################################
 
 imports:
+  function env.DG_OpenSaveGameReader(i32)
+  function env.DG_OpenSaveGameWriter(i32)
   function loading.getWadsSizes(i32, i32)
   function loading.readDataForAllWads(i32, i32)
   function runtimeControl.getTicksMs()
@@ -25,9 +27,6 @@ imports:
   function wasi_snapshot_preview1.fd_write(i32, i32, i32, i32)
   function wasi_snapshot_preview1.path_create_directory(i32, i32, i32)
   function wasi_snapshot_preview1.path_open(i32, i32, i32, i32, i32, i64, i64, i32, i32)
-  function wasi_snapshot_preview1.path_remove_directory(i32, i32, i32)
-  function wasi_snapshot_preview1.path_rename(i32, i32, i32, i32, i32, i32)
-  function wasi_snapshot_preview1.path_unlink_file(i32, i32, i32)
   function wasi_snapshot_preview1.proc_exit(i32)
 
 exports:

--- a/doomgeneric/README.md
+++ b/doomgeneric/README.md
@@ -13,6 +13,8 @@ Include `doomgeneric.h` into your source file and just implement these functions
 * DG_GetTicksMs
 * DG_GetKey
 * DG_SetWindowTitle
+* DG_OpenSaveGameReader
+* DG_OpenSaveGameWriter
 
 |Functions            |Description|
 |---------------------|-----------|
@@ -23,6 +25,8 @@ Include `doomgeneric.h` into your source file and just implement these functions
 |DG_GetTicksMs        |The ticks passed since launch in milliseconds.
 |DG_GetKey            |Provide keyboard events.
 |DG_SetWindowTitle    |Not required to do anything. This is for setting the window title as Doom sets this from WAD file.
+|DG_OpenSaveGameReader|Provide an interface to read the save game data from a specific save slot, return NULL if no save data exists in this slot.
+|DG_OpenSaveGameWriter|Provide an interface to write save game data to a specific save slot.
 
 ### main loop
 At start, call `doomgeneric_Create()`.

--- a/doomgeneric/doomgeneric.h
+++ b/doomgeneric/doomgeneric.h
@@ -7,6 +7,9 @@
 #define DOOMGENERIC_RESX 640
 #define DOOMGENERIC_RESY 400
 
+// number of allowed save game slots
+#define SAVEGAMECOUNT 6
+
 extern uint32_t *DG_ScreenBuffer;
 
 struct DG_WadFileBytes {
@@ -20,6 +23,30 @@ struct DB_BytesForAllWads {
   int numberOfPWads;
 };
 
+typedef struct save_game_reader {
+  // Read bytes and return the number of bytes read
+  size_t (*ReadBytes)(struct save_game_reader *reader,
+                      unsigned char *destination, size_t numberOfBytes);
+  // Return the number of bytes that have been read so far
+  long (*BytesReadSoFar)(struct save_game_reader *reader);
+  // Close the reader, and free all associated resources, including the reader
+  // itself. Use of the given save_game_reader after this function call has
+  // returned will result in undefined behavior.
+  int (*Close)(struct save_game_reader *reader);
+} save_game_reader_t;
+
+typedef struct save_game_writer {
+  // Write bytes and return the number of bytes written
+  size_t (*WriteBytes)(struct save_game_writer *writer, unsigned char *source,
+                       size_t numberOfBytes);
+  // Return the number of bytes that have been written so far
+  long (*BytesWrittenSoFar)(struct save_game_writer *writer);
+  // Close the writer, committing the data written, and free all associated
+  // resources, including the writer itself. Use of the given save_game_writer
+  // after this function call has returned will result in undefined behavior
+  int (*Close)(struct save_game_writer *writer);
+} save_game_writer_t;
+
 void doomgeneric_Create(int argc, char **argv);
 void doomgeneric_Tick();
 
@@ -31,5 +58,8 @@ void DG_SleepMs(uint32_t ms);
 uint32_t DG_GetTicksMs();
 int DG_GetKey(int *pressed, unsigned char *key);
 void DG_SetWindowTitle(const char *title);
+// Return NULL if there is no save game data saved to the given slot
+save_game_reader_t *DG_OpenSaveGameReader(int saveGameSlot);
+save_game_writer_t *DG_OpenSaveGameWriter(int saveGameSlot);
 
 #endif // DOOM_GENERIC

--- a/doomgeneric/include/doomstat.h
+++ b/doomgeneric/include/doomstat.h
@@ -216,7 +216,6 @@ extern wbstartstruct_t wminfo;
 //
 
 // File handling stuff.
-extern char *savegamedir;
 extern char basedefault[1024];
 
 // if true, load all graphics at level load

--- a/doomgeneric/include/g_game.h
+++ b/doomgeneric/include/g_game.h
@@ -39,7 +39,7 @@ void G_DeferedPlayDemo(char *demo);
 
 // Can be called by the startup code or M_Responder,
 // calls P_SetupLevel or W_EnterWorld.
-void G_LoadGame(char *name);
+void G_LoadGame(int slotToLoad);
 
 void G_DoLoadGame(void);
 

--- a/doomgeneric/include/p_saveg.h
+++ b/doomgeneric/include/p_saveg.h
@@ -21,17 +21,11 @@
 
 #include <stdio.h>
 
+#include "doomgeneric.h"
+
 // maximum size of a savegame description
 
 #define SAVESTRINGSIZE 24
-
-// temporary filename to use while saving.
-
-char *P_TempSaveGameFile(void);
-
-// filename to use for a savegame slot
-
-char *P_SaveGameFile(int slot);
 
 // Savegame file header read/write functions
 
@@ -54,7 +48,8 @@ void P_UnArchiveThinkers(void);
 void P_ArchiveSpecials(void);
 void P_UnArchiveSpecials(void);
 
-extern FILE *save_stream;
+extern save_game_reader_t *save_game_reader;
+extern save_game_writer_t *save_game_writer;
 extern boolean savegame_error;
 
 #endif

--- a/doomgeneric/src/d_main.c
+++ b/doomgeneric/src/d_main.c
@@ -84,10 +84,6 @@
 //
 void D_DoomLoop(void);
 
-// Location where savegames are stored
-
-char *savegamedir;
-
 boolean devparm;     // started game with -devparm
 boolean nomonsters;  // checkparm of -nomonsters
 boolean respawnparm; // checkparm of -respawn
@@ -1385,16 +1381,6 @@ void D_DoomMain(void) {
   // we've finished loading Dehacked patches.
   D_SetGameDescription();
 
-#ifdef _WIN32
-  // In -cdrom mode, we write savegames to c:\doomdata as well as configs.
-  if (M_ParmExists("-cdrom")) {
-    savegamedir = configdir;
-  } else
-#endif
-  {
-    savegamedir = M_GetSaveGameDir(D_SaveGameIWADName(gamemission));
-  }
-
   // Check for -file in shareware
   if (modifiedgame) {
     // These are the lumps that will be checked in IWAD,
@@ -1642,8 +1628,7 @@ void D_DoomMain(void) {
   }
 
   if (startloadgame >= 0) {
-    M_StringCopy(file, P_SaveGameFile(startloadgame), sizeof(file));
-    G_LoadGame(file);
+    G_LoadGame(startloadgame);
   }
 
   if (gameaction != ga_loadgame) {

--- a/doomgeneric/src/m_menu.c
+++ b/doomgeneric/src/m_menu.c
@@ -1199,6 +1199,8 @@ boolean M_Responder(event_t *ev) {
 
     case KEY_ENTER:
       saveStringEnter = 0;
+      // Save the game only if the user actually provided a non-empty
+      // name/description for the save game
       if (savegamestrings[saveSlot][0])
         M_DoSave(saveSlot);
       break;


### PR DESCRIPTION
# What's motivating this work?

_Doom_ naturally reads and writes, _from disk_, all the data related to saving the game's state (which allows the user to save and resume their game).

Such an approach doesn't holistically work for WebAssembly, where there is not (if you ignore [WASI](https://wasi.dev/), which we are ignoring) universal support to 'read/write data from a file'.

So instead, because a WebAssembly module must completely interact with the outside world through its imports and exports, we will support _Doom_ reading and writing data for saved game through newly imported functions. 

# What specifically is being done?

This work amounts to two moderate changes, the second which depends upon the first:

1. Internal _Doom_ code is adjusted to fully use custom functions to retrieve and write data for saved games, and the `doomgeneric` interface is adjusted to support this approach (i.e. functions `DG_OpenSaveGameReader` and `DG_OpenSaveGameWriter` are added).
   - The SDL example of leveraging `doomgeneric` is adjusted to use this approach 
2. The `doomgeneric` interface for loading data for saved games is implemented to work via WebAssembly imports
   - `DG_OpenSaveGameReader` and `DG_OpenSaveGameWriter` are implemented via three new functions imported by the WebAssembly module: `gameSaving.sizeOfSaveGame`, `gameSaving.readSaveGame`, and `gameSaving.writeSaveGame`.
