### PR TITLE
Load Doom Shareware WAD When No WAD is Provided

### DIFF
--- a/doom.wasm.interface.txt
+++ b/doom.wasm.interface.txt
@@ -38,4 +38,4 @@ exports:
   global KEY_TAB(i32, mutable = false)
   global KEY_UPARROW(i32, mutable = false)
   global KEY_USE(i32, mutable = false)
-  memory memory(min = 8, max = ∞)
+  memory memory(min = 72, max = ∞)

--- a/src/doom_wasm.c
+++ b/src/doom_wasm.c
@@ -4,6 +4,7 @@
 
 #include "doomgeneric.h"
 #include "doom_wasm.h"
+#include "file_embedded_in_code/DOOM1.WAD.h"
 
 /*
  * This file reconciles the WebAssembly interface (i.e. imports/exports)
@@ -105,9 +106,13 @@ struct DB_BytesForAllWads DG_GetWads() {
       dataForNextWad += byteLengthOfEachWad[i + 1];
     }
   } else {
-    fprintf(
-        stderr,
-        "At least one WAD must be provided, but `getWadsSizes` reported 0.\n");
+    printf("Defaulting to loading Doom shareware WAD because no WAD data was "
+           "provided\n");
+    result.iWad.data = malloc(DOOM1_WAD_length);
+    memcpy(result.iWad.data, DOOM1_WAD_data, DOOM1_WAD_length);
+    result.iWad.byteLength = DOOM1_WAD_length;
+    result.numberOfPWads = 0;
+    result.pWads = 0;
   }
 
   return result;

--- a/utils/generate_code_for_embedded_file.py
+++ b/utils/generate_code_for_embedded_file.py
@@ -1,0 +1,143 @@
+import argparse
+import textwrap
+import os
+import re
+import itertools
+import sys
+from typing import Iterator
+
+
+def convert_to_valid_c_identifier(s: str) -> str:
+  """Mutate a string to turn it into a valid C identifier.
+
+  In particular, the resultant string is non-empty, only contains '_'
+  and alphanumeric characters, and doesn't start with a number.
+  """
+
+  has_only_alpha_numeric_characters = re.sub('[^0-9a-zA-Z]+', '_', s)
+
+  starts_with_letter = has_only_alpha_numeric_characters[0:1].isalpha()
+  return has_only_alpha_numeric_characters if starts_with_letter else "_" + has_only_alpha_numeric_characters
+
+
+def source_file_lines_for_embedded_asset(file_bytes: Iterator[bytes], header_file_name: str, array_variable_name: str, array_length_variable_name: str) -> Iterator[str]:
+  """Produce the lines of the source code file that embed the given bytes as data.
+  """
+
+  COMMA_SEPARATED_HEX_OCTETS_GO_HERE = 'COMMA_SEPARATED_HEX_OCTETS_GO_HERE'
+
+  source_contents = f"""
+    #include "{header_file_name}"
+
+    const unsigned char {array_variable_name}[] = {{{COMMA_SEPARATED_HEX_OCTETS_GO_HERE}}};
+
+    const size_t {array_length_variable_name} = sizeof({array_variable_name}) / sizeof({array_variable_name}[0]);
+  """
+
+  source_content_start, source_content_end = textwrap.dedent(source_contents).split(COMMA_SEPARATED_HEX_OCTETS_GO_HERE)
+
+  # Convert each byte in the file to a '0x' hex value, followed by a comma
+  hex_values = map(lambda b: f'0x{b.hex()},', file_bytes)
+  # Chunk the hex values into smallish groups, we'll put one group on each line
+  batched_hex_values = itertools.batched(hex_values, 16)
+  # Add spaces between the hex values in each chunk and concatenate them into a single string
+  lines_of_hex_values = map(lambda batch: ' '.join(batch), batched_hex_values)
+  # Add a small indentation to each line
+  indented_lines_of_hex_values = map(lambda line: '  ' + line, lines_of_hex_values)
+
+  return itertools.chain(
+    source_content_start.split('\n'),
+    indented_lines_of_hex_values,
+    source_content_end.split('\n')
+  )
+
+
+def header_file_lines_for_embedded_asset(array_variable_name: str, array_length_variable_name: str) -> Iterator[str]:
+  """Produce the lines of the header file that embed the given bytes as data.
+  """
+
+  header_guard_identifier = f"{array_variable_name.upper()}_H_"
+
+  header_contents = f"""
+    #ifndef {header_guard_identifier}
+    #define {header_guard_identifier}
+
+    #include <stddef.h>
+
+    extern const unsigned char {array_variable_name}[];
+    extern const size_t {array_length_variable_name};
+
+    #endif
+  """
+
+  return textwrap.dedent(header_contents).split('\n')
+
+
+def file_contents_iterator(file):
+  """Create an iterator that produces one byte/char of a file at a time"""
+  while True:
+    chunk = file.read(1)
+    if not chunk:
+      break
+    yield chunk
+
+
+def generate_code_for_embedded_asset(input_file, destination_folder: str):
+  """Generate both a C source file and C header file that contains and references,
+  respectively, an embedded copy of the binary data in the given file."""
+
+  input_file_name = os.path.basename(input_file.name)
+
+  header_file_name = f"{input_file_name}.h"
+  source_file_name = f"{input_file_name}.c"
+
+  associated_identifier = convert_to_valid_c_identifier(input_file_name)
+
+  array_variable_name = f"{associated_identifier}_data"
+  array_length_variable_name = f"{associated_identifier}_length"
+
+  # Generate the header file
+  header_file_path = os.path.join(destination_folder, header_file_name)
+  with open(header_file_path, 'w') as header_file:
+
+    header_file_lines = header_file_lines_for_embedded_asset(array_variable_name, array_length_variable_name)
+    for line in header_file_lines:
+      header_file.write(line)
+      header_file.write('\n')
+
+  # Generate the source file
+  source_file_path = os.path.join(destination_folder, source_file_name)
+  with open(source_file_path, 'w') as source_file:
+
+    file_bytes = file_contents_iterator(input_file)
+    source_file_lines = source_file_lines_for_embedded_asset(file_bytes, header_file_name, array_variable_name, array_length_variable_name)
+    for line in source_file_lines:
+      source_file.write(line)
+      source_file.write('\n')
+
+
+if __name__ == "__main__":
+  doc_string = """
+    Generate a C source file and C header file that support referencing an
+    embedded `unsigned char*` that contains exactly the binary contents of a file.
+
+    The generated files are named {x}.h and {x}.c, where {x} is the name of the embedded file.
+
+    The generated source includes two variables:
+      (1) An `const unsigned char*` named `{y}_data` that points to the data of the embedded file.
+      (2) A `const size_t` named `{y}_length` that contains the length of the data in the embedded file.
+
+    {y} is the name of the embedded file, with non-alphanumeric characters replaced with '_'.
+    """
+
+  parser = argparse.ArgumentParser(description=textwrap.dedent(doc_string))
+
+  parser.add_argument('--input', required=True, type=argparse.FileType('rb'), help='The path to a file which will have its data embedded')
+  parser.add_argument('--destination-folder', required=True, help='The path to the directory where the C source file and C header file will be written')
+
+  args = parser.parse_args()
+
+  if not os.path.isdir(args.destination_folder):
+    print(f"The specified destination directory must exist as a directory, the one provided does not: `{args.destination_folder}`", file=sys.stderr)
+  else:
+    generate_code_for_embedded_asset(args.input, args.destination_folder)


### PR DESCRIPTION
# What's motivating this work?

Most users of `doom.wasm` are probably not interested in running _Doom_ with any game data other than the Shareware WAD, which contains the first episode of _Doom 1_.

So, instead of requiring any and all users provide explicit game data to `doom.wasm`, we'll make the default behavior of `doom.wasm` be "Load the Shareware WAD".

# What specifically is being done?

We have embedded the contents of the Doom shareware WAD into the WebAssembly module, and this WAD is loaded when the imported function `wadSizes` reports that there are `0` WADs to load, which is the behavior of `wadSizes` when the implementation of `wadSizes` is empty.

