### PR TITLE
Add Browser Example of Using `doom.wasm`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,6 +329,40 @@ $(BINARYEN_UTILS): ${BINARYEN_DIR}/bin/%: ${BINARYEN_DIR}
 	@echo [Building the Binaryen util '$*']
 	${VB}$(MAKE) --directory=$< $*
 
+
+####################################################################
+# Targets for building and running examples
+####################################################################
+
+# Each directory in "examples/" is expected to represent an example of
+# how to make use of the Doom WebAssemly modulue.
+#
+# Such an 'example' should contain a Makefile in its directory that provides
+# the two targets `build` and `run`. Either of these targets can depend upon the
+# environment varaible PATH_TO_DOOM_WASM being set to point to the Doom
+# WebAssembly module (and an example will leverage PATH_TO_DOOM_WASM in order
+# to read the Doom WebAssembly module).
+
+# Here we provide two targets per example that make it easy to either `build` or
+# `run` that example via this Makefile:
+#
+#    run-example_$(example_name)
+#    build-example_$(example_name)
+
+EXAMPLES_DIR = examples
+EXAMPLES = $(subst /,,$(subst $(EXAMPLES_DIR)/,,$(wildcard $(EXAMPLES_DIR)/*/)) )
+EXAMPLES_BUILD = $(addprefix build-example_, $(EXAMPLES))
+EXAMPLES_RUN = $(addprefix run-example_, $(EXAMPLES))
+
+$(EXAMPLES_BUILD): build-example_%: $(OUTPUT)
+	@echo [Building the example \'$*\']
+	${VB}$(MAKE) --directory=examples/$* build PATH_TO_DOOM_WASM=$(abspath $(OUTPUT))
+
+$(EXAMPLES_RUN): run-example_%: $(OUTPUT)
+	@echo [Running the example \'$*\']
+	${VB}$(MAKE) --directory=examples/$* run PATH_TO_DOOM_WASM=$(abspath $(OUTPUT))
+
+
 ##########################################################
 # Targets for manually running pre-commit tests
 ##########################################################

--- a/examples/browser/.gitignore
+++ b/examples/browser/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the folder where we keep a local copy of doom.wasm
+/assets/

--- a/examples/browser/Makefile
+++ b/examples/browser/Makefile
@@ -1,0 +1,48 @@
+# VERBOSE can be set to 1 to echo all commands performed by this makefile
+ifeq ($(VERBOSE),1)
+	VB=
+else
+	VB=@
+endif
+
+# As part of an 'example' in the doom.wasm project, this Makefile is expected to
+# provide these two make targets:
+#
+#		build
+#			- performs any upfront work and validation to make sure this example can 'run'
+#			- can find the Doom WebAssembly module via the value of the PATH_TO_DOOM_WASM env var
+#		run
+#			- executes the example in some way
+#			- can find the Doom WebAssembly module via the value of the PATH_TO_DOOM_WASM env var
+
+ASSETS = assets
+LOCAL_COPY_OF_DOOM_WASM = $(ASSETS)/doom.wasm
+
+all: build
+
+# Nothing to actual do on 'build'
+build:
+
+$(ASSETS):
+	@echo [Creating output folder \'$@\']
+	$(VB)mkdir -p $@
+
+# Unconditionally (because this is a .PHONY target) save a local copy of the Doom WebAssembly
+# artifact to the path where the HTTP server expects to serve up this artifact.
+$(LOCAL_COPY_OF_DOOM_WASM): | ensure-path-to-doom_wasm-is-properly-set $(ASSETS)
+	@echo [Copying artifact locally to \'$@\']
+	$(VB)cp $(PATH_TO_DOOM_WASM) $@
+
+PORT = 8000
+run: $(LOCAL_COPY_OF_DOOM_WASM)
+	@echo [Serving up Doom in HTML, visit 127.0.0.1:$(PORT)/doom.html to see it]
+	$(VB)python3 -m http.server $(PORT)
+
+ensure-path-to-doom_wasm-is-properly-set:
+ifndef PATH_TO_DOOM_WASM
+	$(error PATH_TO_DOOM_WASM is undefined, this should be set to point to the Doom Webassembly module)
+else ifeq (,$(wildcard $(abspath $(PATH_TO_DOOM_WASM))))
+	$(error PATH_TO_DOOM_WASM ('$(PATH_TO_DOOM_WASM)') does not point to a file that exists)
+endif
+
+.PHONY: run build all ensure-path-to-doom_wasm-is-properly-set $(LOCAL_COPY_OF_DOOM_WASM)

--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -1,0 +1,29 @@
+# Browser Example
+
+Here lives an example of leveraging the _Doom_ WebAssembly module (`doom.wasm`) produced by this repo in order to run _Doom_ in a browser.
+
+This example leverages the minimal number of features in `doom.wasm` in order to run _Doom_.
+
+Particularly, this example only manages these details in order to run _Doom_:
+1. Draw the frames of _Doom_ to an HTML canvas
+1. Report the current time to _Doom_ by using [`performance.now()`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now)
+1. Listen to all [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent) activity on the HTML canvas and forward all relevant ones to _Doom_
+1. Forward _Doom_ `info` and `error` messages to the JavaScript console (not necessary, but helpful!)
+
+What's missing? This example doesn't support loading custom WADs into _Doom_ (instead _Doom_ always loads the [_Doom_ shareware WAD](https://doomwiki.org/wiki/DOOM1.WAD)), and doesn't support the user saving their game progress.
+
+It wouldn't be difficult to add these missing features to this example, but they're being left out so this example is a demonstration of the minimal code needed to get _Doom_ running in this use case.
+
+## Running
+
+The `make` target `run` exists for "running" this example. Running this example means locally serving up a webpage that runs _Doom_.
+
+To run this example one must provide a path to a copy of `doom.wasm`, as produced by this repo, via the `PATH_TO_DOOM_WASM` env variable.
+
+If you've built `doom.wasm` locally then such a path, relative to here, would be `../../build/doom.wasm`. If that's the case then here's how you'd start up a web server that hosts _Doom_ in a webpage:
+
+```bash
+make run PATH_TO_DOOM_WASM=../../build/doom.wasm
+```
+
+After you've done that you can open [127.0.0.1:8000/doom.html](http://127.0.0.1:8000/doom.html) in a browser and play _Doom_!

--- a/examples/browser/doom.html
+++ b/examples/browser/doom.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<!--
+  Doom - playable in a browser!
+
+  Here the Doom WebAssembly module is loaded via JavaScript and it's inputs
+  and output are connected up to an HTML Canvas, making the game fully playable.
+
+  Both 'info' and 'error' messages from Doom are logged to the browser's console.
+
+  The Doom shareware WAD is always loaded as the game's content.
+
+  Saving of the game is not supported.
+-->
+<html>
+  <head>
+    <title>Doom!</title>
+    <script type="text/javascript">
+
+      // Loads Doom and attaches it to the given canvas element
+      function loadDoomGame(canvas) {
+
+        // This reference to the module instance's exported memory will be filled in one the module instance has been loaded successfully.
+        let moduleInstanceMemory = null;
+        let imageData = null; // filled in once we know the (width, height) of Doom's framebuffer
+        let ctx = canvas.getContext('2d');
+
+        // Specify all the imports needed by Doom
+        let imports = {
+          "loading": {
+            "onGameInit": (width, height) => {
+              // Have the canvas be the exact same size as the Doom frame buffer,
+              // so canvas's pixels are 1-to-1 to the pixels in the Doom frame buffer
+              canvas.width = width;
+              canvas.height = height;
+              imageData = ctx.createImageData(canvas.width, canvas.height);
+            },
+            // Provide no WAD data, so the module defaults to using the Doom shareware WAD
+            "wadSizes": () => {},
+            "readWads": () => {},
+          },
+          "ui": {
+            "drawFrame": (indexOfFrameBuffer) => {
+              // Copy all pixels from the Doom frame buffer to the similarly sized ImageData.
+              let doomFrameBuffer = new Uint8Array(moduleInstanceMemory.buffer, indexOfFrameBuffer, canvas.width * canvas.height * 4);
+
+              for (var i = 0; i < (imageData.data.length / 4); i++) {
+                // The pixels in an ImageData are 32-bits with 8-bit color components ordered "RGBA".
+                // See: https://developer.mozilla.org/en-US/docs/Web/API/ImageData/data
+                //
+                // Doom Frame buffer pixels are also 32-bit and have their 8-bit color components
+                // logically ordered "ARGB", but this 32-bit value is stored in little-endian order
+                // (because WebAssembly always orders multi-byte values in a little-endian way),
+                // so the order of the bytes is reversed and is actually "BGRA".
+                imageData.data[4*i+0] = doomFrameBuffer[4*i+2];  // Red
+                imageData.data[4*i+1] = doomFrameBuffer[4*i+1];  // Green
+                imageData.data[4*i+2] = doomFrameBuffer[4*i+0];  // Blue
+                imageData.data[4*i+3] = 255;  // Alpha (make pixel fully opaque)
+              }
+
+              // And then copy the edited ImageData to the canvas's 2d context
+              ctx.putImageData(imageData, 0, 0);
+            },
+          },
+          "runtimeControl": {
+            "timeInMilliseconds": () => BigInt(Math.trunc(performance.now())),
+          },
+          "console": {
+            // Log all 'info' and 'error' messages to the console
+            "onInfoMessage": (messagePtr, length) => {
+              const message = readModuleMemoryAsUtf8String(moduleInstanceMemory, messagePtr, length);
+              console.log(`[Doom stdout] ${message}`);
+            },
+            "onErrorMessage": (messagePtr, length) => {
+              const message = readModuleMemoryAsUtf8String(moduleInstanceMemory, messagePtr, length);
+              console.error(`[Doom stderr] ${message}`);
+            },
+          },
+          "gameSaving": {
+            // Provide no support for saving games
+            "sizeOfSaveGame": () => 0,
+            "readSaveGame": () => 0,
+            "writeSaveGame": () => 0,
+          },
+        };
+
+        // Retrieve the Doom WebAssembly module and instantiate it with our imports
+        WebAssembly.instantiateStreaming(fetch("assets/doom.wasm"), imports).then(({instance}) => {
+
+          let exports = instance.exports;
+          // Cache a reference to the module's exported memory, for use by functions imported by the module
+          moduleInstanceMemory = exports.memory;
+
+          exports.initGame();
+
+          // Sign up to call tickGame once every frame, and Doom likes to run at 35 frames per second
+          setInterval(exports.tickGame, 1000 / 35);
+
+          const doomKeyFromJavascriptKey = new Map([
+            ["ArrowLeft", exports.KEY_LEFTARROW],
+            ["ArrowRight", exports.KEY_RIGHTARROW],
+            ["ArrowUp", exports.KEY_UPARROW],
+            ["ArrowDown", exports.KEY_DOWNARROW],
+            [",", exports.KEY_STRAFE_L],
+            [".", exports.KEY_STRAFE_R],
+            ["Control", exports.KEY_FIRE],
+            [" ", exports.KEY_USE],
+            ["Shift", exports.KEY_SHIFT],
+            ["Tab", exports.KEY_TAB],
+            ["Escape", exports.KEY_ESCAPE],
+            ["Enter", exports.KEY_ENTER],
+            ["Backspace", exports.KEY_BACKSPACE],
+            ["Alt", exports.KEY_ALT],
+          ]);
+
+          // Translate a KeyboardEvent into a possible numerical Doom key, 'consuming' the KeyboardEvent
+          // in the case that such a translation is possible, and returning `null` otherwise.
+          function convertKeyEventToDoomKey(javaScriptKeyEvent) {
+            let correspondingDoomKey = null;
+            if (doomKeyFromJavascriptKey.has(javaScriptKeyEvent.key)) {
+              // Support keys that we've explicitly associated with a Doom key (e.g. "Control")
+              correspondingDoomKey = doomKeyFromJavascriptKey.get(javaScriptKeyEvent.key);
+            } else if (javaScriptKeyEvent.key.length == 1) {
+              // Support keys that are just a single character (e.g. '1'), and in that case
+              // the corresponding Doom key is just the ASCII code of that character.
+              correspondingDoomKey = javaScriptKeyEvent.key.charCodeAt(0);
+            }
+
+            if (correspondingDoomKey !== null) {
+              // If this key event maps to a Doom key then we are going to forward this
+              // user interaction to Doom and should therefore 'consume' the key event.
+              javaScriptKeyEvent.stopPropagation();
+              javaScriptKeyEvent.preventDefault();
+            }
+
+            return correspondingDoomKey;
+          }
+
+          // Listen for keyboard events on the canvas and forward the appropriate ones to Doom
+          canvas.addEventListener('keydown', function(event) {
+            const doomKey = convertKeyEventToDoomKey(event);
+            if (doomKey !== null) {
+              exports.reportKeyDown(doomKey);
+            }
+          });
+          canvas.addEventListener('keyup', function(event) {
+            const doomKey = convertKeyEventToDoomKey(event);
+            if (doomKey != null) {
+              exports.reportKeyUp(doomKey);
+            }
+          });
+        });
+      }
+
+      // Interpret a chuck of bytes, in a memory exported from a WebAssembly module, as a UTF-8 string
+      function readModuleMemoryAsUtf8String(moduleMemory, offsetIntoMemory, stringByteLength) {
+        const buffer8 = new Uint8Array(moduleMemory.buffer);
+
+        const dec = new TextDecoder("utf-8", { fatal: false });
+        const data = buffer8.slice(offsetIntoMemory, offsetIntoMemory + stringByteLength);
+        return dec.decode(data);
+      }
+
+      // On page load, start up Doom
+      addEventListener("load", (event) => {
+        let canvas = document.getElementById("DoomGame");
+        loadDoomGame(canvas);
+      });
+    </script>
+    <style>
+      /*
+        Keyboard input only passes to an HTML canvas when that canvas has focus.
+        Draw the canvas a little bit transparent when it doesn't have focus to better communicate
+        the state of "not receiving user input" to the user.
+      */
+      canvas#DoomGame { opacity: 80%; }
+      canvas#DoomGame:focus { opacity: 100%; }
+    </style>
+  </head>
+  <body>
+    <canvas id="DoomGame" tabindex="0"></canvas>  <!-- tabindex="0" allows the canvas to be focusable, and therefore receive keyboard events -->
+  </body>
+</html>


### PR DESCRIPTION
# What's motivating this work?

We want to provide a few examples of how one might make use of `doom.wasm`.

The first such example will be a browser-based example that runs _Doom_ in a webpage.

# What specifically is being done?

[First](https://github.com/jacobenget/doom.wasm/commit/f19860ae6439ff5efe79fe96e445425b0c280828) we set up some make/build infrastructure for running examples from the top-level directory of this repo. There will be make targets named `build-example_EXAMPLE_NAME` and `run-example_EXAMPLE_NAME` for each folder/example added to the `examples` directory.

[Then](https://github.com/jacobenget/doom.wasm/commit/9ffef3cbebb4e3175712f5b0abe344a7bb6044b5), we add a single HTML file that uses `doom.wasm` to run _Doom_.

Further details, including instructions on running this example, can be found in the [README.md](https://github.com/jacobenget/doom.wasm/blob/ee90d59ea36742c0bc080a320438ca4980354a3f/examples/browser/README.md) for this example.

