### PR TITLE
Take a Stab at Improving Top-level Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,211 @@
-# doom.wasm
+# `doom.wasm`
 
-This project's aim is to compile the Doom source to WebAssembly, producing a module with a small and easy-to-understand interface.
+Providing a [WebAssembly](https://webassembly.org/) module that can fully run [_Doom_](https://en.wikipedia.org/wiki/Doom_(1993_video_game)) while having a small and easy-to-understand interface.
 
-This project takes advantage of much work done previously by others to make the Doom source code easy to build and easy to interface with. Particularly, the work done in these projects built the ground upon which this project stands:=
-[doomgeneric](https://github.com/ozkl/doomgeneric), [fbDoom](https://github.com/maximevince/fbDOOM), [Frosted Doom](https://github.com/insane-adding-machines/DOOM), and [Chocolate Doom](https://github.com/chocolate-doom/chocolate-doom).
+## Why?
+
+Wait, hasn't _Doom_ already been ported to WebAssembly?
+
+Yes. Definitely. So many times.
+
+This issue is that past attempts to compile _Doom_ to WebAssembly have only had the "Human who wants to play _Doom_" user in mind. These attempts demonstrate running _Doom_ somewhere interesting (e.g. in a browser) but fail to be more than a tech or research demo.
+
+In particular, none of these past attempts produced a _Doom_ WebAssembly module that can be easily leveraged to, using any WebAssembly runtime, run _Doom_ in a new way.
+
+Look at a measure of interface "surface area" of the WebAssembly modules produced by a few "_Doom_ running on WebAssembly" projects in the wild:
+
+| Project | Imported Functions | Exported Functions | Surface Area (Imported and Exported Functions) | Notes |
+| ---- | ---- | ---- | ---- | ---- |
+| [cloudflare/doom-wasm](https://github.com/cloudflare/doom-wasm) | 259 | 62 | 321 | Powers the app hosted [here](https://silentspacemarine.com/). |
+| [lazarv/wasm-doom](https://github.com/lazarv/wasm-doom) | 248 | 32 | 280 | Powers the [WAD Commander](https://wadcmd.com/) tool. |
+| [diekmann/wasm-fizzbuzz/doom](https://github.com/diekmann/wasm-fizzbuzz/tree/main/doom#but-can-it-run-doom) | 5 | 48 | 53 | Powers the app hosted [here](https://diekmann.github.io/wasm-fizzbuzz/doom/). Doesn't support the core _Doom_ feature of loading custom WAD data. |
+| [UstymUkhman/webDOOM](https://github.com/UstymUkhman/webDOOM) | 365 | 39 | 404 | Powers the app hosted [here](http://35.158.218.205/experiments/webDOOM/). |
+| [raz0red/webprboom](https://github.com/raz0red/webprboom) | 372 | 43 | 415 | Powers the app hosted [here](https://raz0red.github.io/webprboom/). |
+| [VanIseghemThomas/wasmDOOM](https://github.com/VanIseghemThomas/wasmDOOM) | 247 | 15 | 262 | Must be built from source |
+
+Understanding anywhere from 50 to 400+ different functions defined by a WebAssembly module, either to implement or use, is not an easy task!
+
+We can do better, and hope to keep the spirit of _Doom_'s impressive portability alive by compiling _Doom_ to a WebAssembly module that has a minimal and curated interface.
+
+We've succeeded in producing a _Doom_ WebAssembly module that only imports 10 functions and exports 4 functions, resulting in an interface "surface area" of 14!
+
+| Project | Imported Functions | Exported Functions | Surface Area (Imported and Exported Functions) | Notes |
+| ---- | ---- | ---- | ---- | ---- |
+| `doom.wasm` | 10 | 4 | 14 | Supports loading of custom WAD data. |
+
+Further information on this simple interface is located in [Details](#details).
+
+Also, the maximum size of the WebAssembly `memory` needed by the _Doom_ WebAssembly module when it loads the [Doom Shareware WAD](https://doomwiki.org/wiki/DOOM1.WAD) is 248 WebAssembly memory `pages`, which are 2^16 bytes each, so this comes to about 16MB.
+
+This means we've reduced the question
+
+> [Can it run _Doom_?](https://canitrundoom.org/)
+
+to
+
+> Can it run a WebAssembly interpreter while having enough RAM for a 16MB WebAssembly memory?
+
+## Building
+
+Producing the WebAssembly module for _Doom_ (referred to as `doom.wasm` from now on), can be done via
+
+```bash
+make all
+```
+
+You will then find the module at `build/doom.wasm`.
+
+### Requirements
+
+Building this project requires that your system has these resources available:
+- [Python](https://www.python.org/downloads/), version 3+
+- `docker` (version `24.0.6` tested)
+- `make` (GNU Make version `3.81` tested)
+- `curl` (version `8.1.2` tested)
+- `git` (version `2.43.0` tested)
+
+## Running
+
+The [`examples`](examples/) directory contains a few examples of using `doom.wasm` to run _Doom_.
+
+Currently, there are three such examples:
+1. [`browser`](examples/browser/): Runs _Doom_ in a webpage, using the browser's support for WebAssembly and drawing frames of _Doom_ to an HTML Canvas
+2. [`native`](examples/native/): Runs _Doom_ natively, leveraging the [Wasmtime](https://wasmtime.dev/) WebAssembly runtime and [SDL](https://www.libsdl.org/)
+2. [`python`](examples/python/): Runs _Doom_ via [Python](https://www.python.org/), leveraging the [`wasmtime`](https://pypi.org/project/wasmtime/) Python bindings to the [Wasmtime](https://wasmtime.dev/) WebAssembly runtime, and [PyGame](https://www.pygame.org/wiki/about)
+
+Each of these examples can be run from the top-level directory of this repo via a `make` target named `run-example_<example-name>`, e.g.:
+
+```bash
+make run-example_browser # start a local web server that hosts Doom in a webpage
+```
+
+```bash
+make run-example_native # start Doom natively
+```
+
+```bash
+make run-example_python # start Doom via Python
+```
+
+## Details
+
+The interface of `doom.wasm` is comprised of:
+- 10 imported functions
+- 4 exported functions
+- an exported `memory`
+- 14 exported global constants (which exist purely to improve usability)
+
+[`doom.wasm.interface.txt`](doom.wasm.interface.txt) contains a quick glance at the interface of `doom.wasm`. More details are provided below.
+
+### Imports
+
+A user of `doom.wasm` is expected to provide implementations of all these imported functions.
+
+Note that almost all of these imports can have trivial or empty implementations if you have no use for the specific utility they provide!
+
+| Function Name (including module prefix) | Expected Behavior | Notes |
+| ---- | ---- | ---- |
+| `loading.onGameInit` | Respond to _Doom_ first starting up | Perform any one-time initialization here |
+| `loading.wadSizes` | Report size information about the WAD data that _Doom_ should load | Can do nothing, which communicates to _Doom_ "Load the [Doom Shareware WAD](https://doomwiki.org/wiki/DOOM1.WAD)" |
+| `loading.readWads` | Copy to memory the data for all WAD files that _Doom_ should load, and the byte length of each WAD file | Only called if `loading.wadSizes` reported a greater-than-zero number of WADs to load |
+| `runtimeControl.timeInMilliseconds` | Provide a representation of the current 'time', in milliseconds | |
+| `ui.drawFrame` | Respond to a new frame of the _Doom_ game being available | |
+| `gameSaving.sizeOfSaveGame` | Report the size, in bytes, of a specific save game | |
+| `gameSaving.readSaveGame` | Copy data for a specific save game to memory | Only called if `gameSaving.sizeOfSaveGame` reported a save game with a non-zero size |
+| `gameSaving.writeSaveGame` | Respond to the user attempting to save their game | Can just return `0` in the case that game saving isn't supported |
+| `console.onInfoMessage` | Respond to _Doom_ reporting an info message | |
+| `console.onErrorMessage` | Respond to _Doom_ reporting an error message | |
+
+### Exports
+
+#### Memory
+
+The linear memory of _Doom_ is exported by `doom.wasm`.
+
+This gives _Doom_ and the functions it has imported a shared space to read and write arbitrarily-sized data, e.g. when `ui.drawFrame` needs access to _Doom_'s frame buffer.
+
+#### Functions
+
+Four functions are exported by `doom.wasm`. The user should call these to run _Doom_.
+
+| Function Name  | Behavior |
+| ---- | ---- |
+| `initGame()` | Initialize _Doom_; must be called before any other exported function is called |
+| `tickGame()` | Advance _Doom_ by one 'tick' (i.e. one frame) |
+| `reportKeyDown(doomKey: i32)` | Report to _Doom_ that a key is now pressed down |
+| `reportKeyUp(doomKey: i32)` | Report to _Doom_ that a key is no longer pressed down |
+
+#### Constants
+
+Two functions exported by `doom.wasm`, `reportKeyDown` and `reportKeyUp`, accept an integer `doomKey` argument. This integer `doomKey` argument fills to role of representing all the "keys" that _Doom_ responds to.
+
+But what values of `doomKey` should be associated with what keyboard keys?
+
+Many "keys" that _Doom_ responds to (e.g. the keys `1` through `9`) are naturally associated with keyboard keys that produce a single printable character when pressed. In that case the `doomKey` value for that key is exactly the Unicode value representing the unmodified character generated by pressing that keyboard key. E.g. pass `49` to `reportKeyDown` when the player presses `1` on their keyboard.
+
+Other "keys" that _Doom_ responds to either have Unicode values that aren't printable (e.g. `8`, for Unicode `backspace`) or have no Unicode equivalent (e.g. the "USE" key, which is used to open doors and flip switches in _Doom_).
+
+To help in those cases, global constants with descriptive names have been exported by `doom.wasm`. Each global constant holds the `doomKey` value for one of these special "keys", and its this integer value that should be passed to `reportKeyDown` or `reportKeyUp` whenever the player has pressed or unpressed, respectively, the associated keyboard key.
+
+Here's a table of all such global constants, along with a hint at what keyboard key might trigger such a "key" (based on [controls in vanilla _Doom_](https://doom.fandom.com/wiki/Controls)).
+
+| Global Key Constant Name | Keyboard key vanilla _Doom_ (where not obvious) |
+| ---- | ---- |
+| `KEY_LEFTARROW` | |
+| `KEY_RIGHTARROW` | |
+| `KEY_UPARROW` | |
+| `KEY_DOWNARROW` | |
+| `KEY_STRAFE_L` | comma key: `,` |
+| `KEY_STRAFE_R` | period key: `.` |
+| `KEY_FIRE` | control key |
+| `KEY_USE` | space bar |
+| `KEY_SHIFT` | |
+| `KEY_TAB` | |
+| `KEY_ESCAPE` | |
+| `KEY_ENTER` | |
+| `KEY_BACKSPACE` | |
+| `KEY_ALT` | |
+
+#### Main Loop
+
+After providing appropriate implementations for all functions imported by `doom.wasm`, and then instantiating the WebAssembly module, the common way you'd run _Doom_ is by calling `initGame()` once (required) followed by an unbounded number of calls to `tickGame()`, `reportKeyDown(doomKey)`, and `reportKeyUp(doomKey)`, in an infinite loop.
+
+Here's pseudocode illustrating this:
+
+```
+doomExports.initGame()
+
+while (True):
+   doomExports.tickGame()
+
+   for (keyStateChange in userInput):
+
+      if keyStateChange.key is associated with a specialKey:
+         doomKey = value stored in the associated global KEY_* constant
+      else:
+         doomKey = keyStateChange.key.unicodeValue
+
+      if (keyStateChange.keyIsPressed):
+         doomExports.reportKeyDown(doomKey)
+      else:
+         doomExports.reportKeyUp(doomKey)
+```
+
+See a concrete example of such a main loop in the implementation of `run_game` [here (C)](examples/native/src/imports_via_SDL/doom_imports.c) and in the implementation of `main` [here (Python)](examples/python/main.py).
+
+Note that you could call `tickGame()` less aggressively than in this pseudocode.
+
+The rate at which `tickGame()` is called does _not_ affect the rate at which time passes in the game. The passing of time in-game is instead controlled by the implementation of the imported function `runtimeControl.timeInMilliseconds`. The rate at which `tickGame()` is called just determines how often user input is processed and a frame of _Doom_ is rendered.
+
+_Doom_ naturally wants to be rendered at 35 frames per second (this is the framerate of the game when it was first released in 1993), so calling `tickGame()` much less than 35 times per second will result in the game feeling sluggish. But feel free to call `tickGame()` _only_ 35 times a second, the game will still feel responsive.
+
+### Further Details
+
+The exact shape of all elements imported and exported by `doom.wasm` can be found in [`doom.wasm.interface.txt`](doom.wasm.interface.txt). This file is auto-generated on each commit, so it immediately surfaces any changes to the interface of `doom.wasm` caused by changes elsewhere. This should be considered an authority on the shape of the interface to `doom.wasm`.
+
+The expected behavior and signature of all imports, and further details about how to use any exported function, lives in [src/doom_wasm.h](src/doom_wasm.h). This is the C header file declaring all functions exported and imported by _Doom_.
+
+Also, both the [`native`](examples/native/) and [`python`](examples/python/) examples present in this repo contain full implementations of all imports needed by `doom.wasm`, and fully leverage all exports provided by `doom.wasm`. Studying these examples will likely fill in any gaps any related questions you might have.
 
 ## Development
 
@@ -16,3 +218,30 @@ This is accomplished by initializing the dev setup for this repo via this comman
 ```
 make dev-init
 ```
+
+## TODO
+
+There are many wishlist items worth accomplishing next with `doom.wasm`, but these missing pieces stand out enough to be worth mentioning (because you may be scratching your head about them):
+1. Add support for music and sound effects
+    - `doom.wasm` produces no music or sound effects when played!
+    - The music of _Doom_ is iconic, and _Doom_ isn't _Doom_ without its aural components paired with its visual components
+    - Adding music and sound effect support won't be trivial, likely complicated by the non-standard way that music and sound effects are stored in memory by _Doom_
+2. Support "screen melt" effect in single-threaded environments
+   - The ["screen melt" effect](https://doom.fandom.com/wiki/Screen_melt) is completely performed by _Doom_, from beginning to end, in a single call to `tickGame()`
+   - This means that if `doom.wasm` is running on a platform where rendering of a frame of _Doom_ only happens when the main thread of execution is released (e.g. a browser) the user will not see any intermediate frames of this animation
+   - Oh no!
+   - Instead, a user on such a platform will experience a frozen game as they wait for the "screen melt" to complete behind the scenes, and for this very long call to `tickGame()` to return
+   - This would be addressed by performing the animation of the "screen melt" asynchronously
+   - A call to `tickGame()` where this animation starts or is in progress would have to return after rendering just _one_ frame of the animation, and then be capable of resuming the animation on the next call to `tickGame()`
+3. Build from scratch in less time
+   - Constructing `doom.wasm` requires a few [Binaryen](https://github.com/WebAssembly/binaryen) tools
+   - The tools are built locally, and when built from scratch can take over an hour to build
+   - This means that a build of `doom.wasm` from a fresh clone of this repo likely takes over an hour, ugh
+   - Leverage a `docker` image containing pre-built Binaryen tools to seriously cut down this 'time to build from scratch'
+
+## Credit Where Credit is Due
+
+This project takes advantage of much work done previously by others to make the _Doom_ source code easy to build and easy to interface with.
+
+Particularly, these other projects built the ground upon which this project stands:
+[doomgeneric](https://github.com/ozkl/doomgeneric), [fbDoom](https://github.com/maximevince/fbDOOM), [Frosted Doom](https://github.com/insane-adding-machines/DOOM), and [Chocolate Doom](https://github.com/chocolate-doom/chocolate-doom). Many thanks go to them!

--- a/src/doom_wasm.h
+++ b/src/doom_wasm.h
@@ -16,46 +16,264 @@
 // *                             EXPORTED FUNCTIONS                            *
 // *****************************************************************************
 
-// NOTE: `_initializeDoom` is exported and then externally combined with the
-// auto-generated and exported function `_initialize` to produce the single
-// exported function named `initGame`.
-//
-// This is done so the user of this WebAssembly module only has one exported
-// 'init' function they're expected to call: `initGame`.
-//
-// ps. An `_initialize` function is auto-generated and then exported because
-// this module is built as a WASI 'reactor', see here:
-// https://github.com/WebAssembly/WASI/blob/main/legacy/application-abi.md#current-unstable-abi
+/*
+ * Initialize Doom - exported as part of the function `initGame()`
+ *
+ * NOTE: `_initializeDoom` is exported and then externally combined with the
+ * auto-generated and exported function `_initialize` to produce the single
+ * exported function named `initGame`.
+ *
+ * This is done so the user of this WebAssembly module only has one exported
+ * 'init' function they're expected to call: `initGame`.
+ *
+ * ps. An `_initialize` function is auto-generated and then exported because
+ * this module is built as a WASI 'reactor', see here:
+ * https://github.com/WebAssembly/WASI/blob/main/legacy/application-abi.md#current-unstable-abi
+ */
 EXPORT void _initializeDoom();
+
+/*
+ * Advance Doom by one 'tick' (i.e. one frame)
+ *
+ * Allows Doom to render a new frame after reacting to any key state changes
+ * reported since the last `tick`.
+ */
 EXPORT void tickGame();
+
+/*
+ * Report to Doom that a key is now pressed down
+ *
+ * args:
+ *  doomKey:
+ *    - A numerical representation of the key, in the range [0, 255]
+ *    - If the key in question naturally produces a printable ASCII character:
+ *      - then the `doomKey` associated with the key is the ASCII code for that
+ *        printable character
+ *      - e.g. the keys 'a' through 'z' have a `doomKey` value of 97 through
+ *        122, respectively
+ *    - Otherwise:
+ *      - then the `doomKey` associated with the key is some special value
+ *      - e.g. the key for "USE"
+ *      - all such special `doomKey` values are exported from `doom.wasm` as
+ *        global constants with a helpful descriptive name (e.g. "KEY_USE")
+ *
+ * Note: calling this function with a `doomKey` value outside of the range [0,
+ * 255] only results in a logged error message, no other harm is done
+ *
+ * Note: multiple calls to this function with the same `doomKey`, without a call
+ * to `reportKeyUp` with the same `doomKey` in between, will just be ignored
+ */
 EXPORT void reportKeyDown(int32_t doomKey);
+
+/*
+ * Report to Doom that a key is no longer pressed down
+ *
+ * args:
+ *  doomKey:
+ *    - A numerical representation of the key, in the range [0, 255]
+ *    - If the key in question naturally produces a printable ASCII character:
+ *      - then the `doomKey` associated with the key is the ASCII code for that
+ *        printable character
+ *      - e.g. the keys 'a' through 'z'
+ *    - Otherwise:
+ *      - then the `doomKey` associated with the key is some special value
+ *      - e.g. the key for "USE"
+ *      - all such special `doomKey` values are exported from `doom.wasm` as
+ *        global constants with a helpful descriptive name (e.g. "KEY_USE")
+ *
+ * Note: calling this function with a `doomKey` value outside of the range [0,
+ * 255] only results in a logged error message, no other harm is done
+ *
+ * Note: multiple calls to this function with the same `doomKey`, without a call
+ * to `reportKeyDown` with the same `doomKey` in between, will just be ignored
+ */
 EXPORT void reportKeyUp(int32_t doomKey);
 
 // *****************************************************************************
 // *                             IMPORTED FUNCTIONS                            *
 // *****************************************************************************
 
+/*
+ * Perform one-time initialization upon Doom first starting up
+ *
+ * args:
+ *  width:
+ *    - width, in pixels, of frame buffer passed to `drawFrame`
+ *  height:
+ *    - height, in pixels, of frame buffer passed to `drawFrame`
+ */
 IMPORT_MODULE("loading") void onGameInit(int32_t width, int32_t height);
+
+/*
+ * Report size information about the WAD data that Doom should load
+ *
+ * The information provided by this function allows Doom to prepare the space
+ * in memory needed to then call `readWads` to receive the data in all WADs that
+ * are to be loaded by Doom.
+ *
+ * The value stored in `*numberOfWads` before this function is called is 0. The
+ * value of `*numberOfWads` still being 0 when this function returns
+ * communicates to Doom "No custom WAD data to load; please load the Doom
+ * shareware WAD instead".
+ *
+ * In other words, this function is allowed to do nothing and that will result
+ * in `readWads` NOT being called and the Doom Shareware WAD being loaded into
+ * Doom.
+ *
+ * args:
+ *  numberOfWads:
+ *    - pointer to the number of WADs that Doom will be loading
+ *  numberOfTotalBytesInAllWads:
+ *    - pointer to the total combined size, in bytes, of the WADs that Doom
+ * should load
+ */
 IMPORT_MODULE("loading")
 void wadSizes(int32_t *numberOfWads, size_t *numberOfTotalBytesInAllWads);
+
+/*
+ * Copy to memory the data for all WAD files that Doom should load, and the byte
+ * length of each WAD file
+ *
+ * To understand how this function operates, consider that this function is
+ * called immediately after Doom calls `wadSizes`, and `wadSizes` provided these
+ * two values: `numberOfWads`
+ *    - the number of WAD files that should be loaded
+ *  `numberOfTotalBytesInAllWads`
+ *    - the total length, in bytes, of all WAD files combined
+ *
+ * This function is only called if the `numberOfWads` value provided by
+ * `wadSizes` is greater than 0.
+ *
+ * args:
+ *  wadDataDestination:
+ *    - location in memory where the data for all WAD files should be written,
+ *      end-to-end. The order that the WADs are written here determines the
+ *      order in which Doom loads them. The number of bytes available to write
+ *      to at `wadDataDestination` is exactly `numberOfTotalBytesInAllWads`, and
+ *      this function is expected to write exactly that number of bytes.
+ *  byteLengthOfEachWad:
+ *    - location in memory where an array of `int32_t` values with length
+ *      `numberOfWads` exists. This array should be populated with exactly
+ *      `numberOfWads` values, each which is the byte length of the respective
+ *      WAD file.
+ */
 IMPORT_MODULE("loading")
 void readWads(uint8_t *wadDataDestination, int32_t *byteLengthOfEachWad);
 
+/*
+ * Respond to a new frame of the Doom game being available
+ *
+ * args:
+ *  screenBuffer:
+ *    - pointer to Doom's frame buffer.
+ *      - Doom's frame buffer is exactly `width`*`height` 32-bit pixels
+ *        contiguous in memory, where `width` and `height` were the values
+ *        previously passed to `onGameInit`
+ *      - The pixels are ordered row major, from top-left pixel (index 0) to
+ *        bottom-right (index `width`*`height`)
+ *      - The color data in each 32-bit pixel is made up of four 8-bit color
+ *        components packed in the order BGRA (i.e. Blue, Green, Red, Alpha),
+ *        from low/first byte to high/last byte when the 32-bit pixel is seen
+ *        as an array of 4 bytes.
+ */
 IMPORT_MODULE("ui") void drawFrame(uint32_t *screenBuffer);
 
+/*
+ * Respond to Doom reporting an info message
+ *
+ * args:
+ *  message:
+ *    - the message itself; NOT NULL-terminated like a usual C-string
+ *  length:
+ *    - length, in bytes, of the message
+ */
 IMPORT_MODULE("console") void onInfoMessage(const char *message, size_t length);
+
+/*
+ * Respond to Doom reporting an error message
+ *
+ * args:
+ *  message:
+ *    - the message itself; NOT NULL-terminated like a usual C-string
+ *  length:
+ *    - length, in bytes, of the message
+ */
 IMPORT_MODULE("console")
 void onErrorMessage(const char *message, size_t length);
 
+/*
+ * Provide a representation of the current 'time', in milliseconds
+ *
+ * This function may never return a value that is smaller than a value it
+ * previously returned, but that's the only requirement on how this function is
+ * implemented.
+ *
+ * This function controls how time passes in Doom. A natural implementation of
+ * this function would return the number of milliseconds that have passed since
+ * some fixed point in time.
+ *
+ * returns:
+ *  a value representing the current time, in milliseconds
+ */
 IMPORT_MODULE("runtimeControl") uint64_t timeInMilliseconds();
 
-// Return the size of the associated save game data, 0 in the case that no save
-// data exists for this slot
+/*
+ * Report the size, in bytes, of a specific save game
+ *
+ * This information provided by this function allows Doom to prepare any space
+ * in memory needed to then call `readSaveGame` to receive the data associated
+ * with a specific save game.
+ *
+ * args:
+ *  gameSaveId:
+ *    - identifies a specific save game
+ *
+ * returns:
+ *  Number of bytes in the associated save game data. Returns 0 if no save game
+ *  data exists for this `gameSaveId`.
+ */
 IMPORT_MODULE("gameSaving") size_t sizeOfSaveGame(int32_t gameSaveId);
-// Return the number of bytes read
+
+/*
+ * Copy data for a specific save game to memory
+ *
+ * args:
+ *  gameSaveId:
+ *    - id associated with the save game
+ *    - saved games are identified completely by this number
+ *  dataDestination:
+ *    - location in memory where the bytes of the save game should be copied.
+ *      It's guaranteed that at least `X` bytes are reserved in memory to hold
+ *      this save game data, where `X` is the value last returned when
+ *      `gameSaving_sizeOfSaveGame` was called with the given `gameSaveId`.
+ *
+ * returns:
+ *  Number of bytes of data game data actually copied.
+ *
+ * Note: this function will only ever be called if `sizeOfSaveGame` returned a
+ * non-zero value for this `gameSaveId`.
+ */
 IMPORT_MODULE("gameSaving")
 size_t readSaveGame(int32_t gameSaveId, uint8_t *dataDestination);
-// Return the number of bytes written
+
+/*
+ * Respond to the user attempting to save their game
+ *
+ * args:
+ *  gameSaveId:
+ *    - id associated with the save game
+ *    - saved game are identified completely by this number
+ *  data:
+ *    - location of the bytes of the save game data
+ *  length:
+ *    - the length, in bytes, of the save game data
+ *
+ * returns:
+ *  Number of bytes of data game data actually persisted
+ *
+ * Note: this function should return 0 in the case where saving of games isn't
+ * supported.
+ */
 IMPORT_MODULE("gameSaving")
 size_t writeSaveGame(int32_t gameSaveId, uint8_t *data, size_t length);
 


### PR DESCRIPTION
# What's motivating this work?

Up until now we haven't focused on the higher-level documentation present in this repo.

In particular, we haven't touched the [repo-level README](https://github.com/jacobenget/doom.wasm/blob/102ede0fbfe9881c4cac455f6612491b64dc06de/README.md) or the main C header file ([`doom_wasm.h`](https://github.com/jacobenget/doom.wasm/blob/102ede0fbfe9881c4cac455f6612491b64dc06de/src/doom_wasm.h)) that defines the WebAssembly imports and exports of `doom.wasm`.

These are two bits of documentation that'll matter the most to any visiting user that intends to make use of `doom.wasm`, and we should make a solid pass at populating them with useful information.

This PR does just that.

# What specifically is being done?

The top-level README is fleshed out to contain comprehensive sections that answer these questions:
- Why does this project exist? What is its purpose?
- How do you build `doom.wasm`?
- How do you build and run one of the projects that serve as an example of using `doom.wasm`?
- What are the details of the interface to `doom.wasm`, and how is it expected that a consumer of `doom.wasm` would interact with `doom.wasm` through this interface?

The main C header file now contains comprehensive documentation on the inputs and outputs of all functions imported and exported by `doom.wasm`.

Together, these changes should arm a user with enough knowledge to be successful in whatever use for `doom.wasm` they have in mind, and orient them on how to leverage `doom.wasm` through the examples already present in this project.
