### PR TITLE
Fix Issue With Running `make all` From a Fresh Clone of Repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ $(OUTPUT_DIR)/DOOM1.WAD: | $(OUTPUT_DIR)
 	$(VB)curl --output $(OUTPUT_DIR)/DOOM1.WAD https://distro.ibiblio.org/slitaz/sources/packages/d/doom1.wad
 
 # Support generating .c and .h files that contain and reference, respectively, an embedded copy of another file
-$(FILE_EMBEDDED_IN_CODE_DIR)/%.c $(FILE_EMBEDDED_IN_CODE_DIR)/%.h: $(OUTPUT_DIR)/% utils/generate_code_for_embedded_file.py | $(FILE_EMBEDDED_IN_CODE_DIR)
+$(FILE_EMBEDDED_IN_CODE_DIR)/%.c $(FILE_EMBEDDED_IN_CODE_DIR)/%.h: $(OUTPUT_DIR)/% utils/generate_code_for_embedded_file.py | $(FILE_EMBEDDED_IN_CODE_DIR) ${DEV_PYTHON_VIRTUAL_ENV}
 	@echo [Here's what we're depending on: ${DEV_PYTHON_VIRTUAL_ENV}]
 	@echo [Generating $(<F).c and $(<F).h, the source and header file to embed '$<']
 	${VB}( \


### PR DESCRIPTION
# What's motivating this work?

Running `make all` from a fresh clone of this repo was failing to successfully produce the final `doom.wasm` artifact.

The issue was that the `make` target that produces the C source files that embed the Doom Shareware WAD wasn't 'depending' upon ( in a `make` way) the local Python dev virtual environment, but was making use of this local Python dev virtual environment in order to run the Python script that does its work.

This meant that `make all` was failing when it attempting to activate a local Python dev environment that wasn't actually there.

This needed to be fixed. 

# What specifically is being done?

The `make` dependency mentioned above has been added [here](https://github.com/jacobenget/doom.wasm/commit/3407cf18b27f57af0335539316ddae9b3dfd73aa), and that's the bulk of the fix needed.

The only other tricky piece though is that for this `make` dependency to be added we needed to re-order things in the Makefile so `DEV_PYTHON_VIRTUAL_ENV` could be referenced at this point in the Makefile.  That reordering happened [here](https://github.com/jacobenget/doom.wasm/commit/013e682a53071195215920aba50c5fdce4edb84c).