### PR TITLE
Provide Appropriate Links to Live Browser Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Providing a [WebAssembly](https://webassembly.org/) module that can fully run [_Doom_](https://en.wikipedia.org/wiki/Doom_(1993_video_game)) while having a small and easy-to-understand interface.
 
+[Here](https://jacobenget.github.io/doom.wasm/examples/browser/doom.html) is a bare-bones (i.e. the source code is very simple, take a look!) example of using this WebAssembly module to run _Doom_ in the browser.
+
 ## Why?
 
 Wait, hasn't _Doom_ already been ported to WebAssembly?
@@ -31,7 +33,7 @@ We've succeeded in producing a _Doom_ WebAssembly module that only imports 10 fu
 
 | Project | Imported Functions | Exported Functions | Surface Area (Imported and Exported Functions) | Notes |
 | ---- | ---- | ---- | ---- | ---- |
-| `doom.wasm` | 10 | 4 | 14 | Supports loading of custom WAD data. |
+| `doom.wasm` | 10 | 4 | 14 | Powers the app hosted [here](https://jacobenget.github.io/doom.wasm/examples/browser/doom.html). Supports loading of custom WAD data. |
 
 Further information on this simple interface is located in [Details](#details).
 
@@ -70,8 +72,9 @@ The [`examples`](examples/) directory contains a few examples of using `doom.was
 
 Currently, there are three such examples:
 1. [`browser`](examples/browser/): Runs _Doom_ in a webpage, using the browser's support for WebAssembly and drawing frames of _Doom_ to an HTML Canvas
-2. [`native`](examples/native/): Runs _Doom_ natively, leveraging the [Wasmtime](https://wasmtime.dev/) WebAssembly runtime and [SDL](https://www.libsdl.org/)
-2. [`python`](examples/python/): Runs _Doom_ via [Python](https://www.python.org/), leveraging the [`wasmtime`](https://pypi.org/project/wasmtime/) Python bindings to the [Wasmtime](https://wasmtime.dev/) WebAssembly runtime, and [PyGame](https://www.pygame.org/wiki/about)
+   - This example is hosted live [here](https://jacobenget.github.io/doom.wasm/examples/browser/doom.html)
+1. [`native`](examples/native/): Runs _Doom_ natively, leveraging the [Wasmtime](https://wasmtime.dev/) WebAssembly runtime and [SDL](https://www.libsdl.org/)
+1. [`python`](examples/python/): Runs _Doom_ via [Python](https://www.python.org/), leveraging the [`wasmtime`](https://pypi.org/project/wasmtime/) Python bindings to the [Wasmtime](https://wasmtime.dev/) WebAssembly runtime, and [PyGame](https://www.pygame.org/wiki/about)
 
 Each of these examples can be run from the top-level directory of this repo via a `make` target named `run-example_<example-name>`, e.g.:
 

--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -16,7 +16,9 @@ It wouldn't be difficult to add these missing features to this example, but they
 
 ## Running
 
-The `make` target `run` exists for "running" this example. Running this example means locally serving up a webpage that runs _Doom_.
+This example is hosted live [here](https://jacobenget.github.io/doom.wasm/examples/browser/doom.html).
+
+The `make` target `run` exists for "running" this example locally. Running this example means locally serving up a webpage that runs _Doom_.
 
 To run this example one must provide a path to a copy of `doom.wasm`, as produced by this repo, via the `PATH_TO_DOOM_WASM` env variable.
 


### PR DESCRIPTION
# What's motivating this work?

Via Github Pages, we now have a version of _Doom_ running via `doom.wasm`, [here](https://jacobenget.github.io/doom.wasm/examples/browser/doom.html). Yay!

We should provide links to this running example where ever appropriate in our documentation.

# What changes are being made?

The main README now points to this example in all of these places:
- In its very top, attention-getting, section
- In the 'Notes' column of the `doom.wasm` row in the tables where different instances of "_Doom_ compiled to WebAssembly" are compared
- Where the `browser` example in mentioned in the list of current examples

And the README for the `browser` example also points to this example.