### PR TITLE
Browser Example: support easy embedding of this example in an iframe

### DIFF
--- a/examples/browser/doom.html
+++ b/examples/browser/doom.html
@@ -209,6 +209,19 @@
       */
       canvas#DoomGame { opacity: 80%; }
       canvas#DoomGame:focus { opacity: 100%; }
+
+      /*
+        Adjust default stylings so the `body` of this page perfectly hugs the contained `canvas`,
+        with no surrounding whitespace.
+
+        With this change one can embed this page in an `iframe` elsewhere and that `iframe` will
+        faithfully show just the contained `canvas`.
+      */
+      canvas#DoomGame { display: block; }
+      body {
+        margin: 0px;
+        padding: 0px;
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
# What's motivating this work?

The example of using `doom.wasm` to run Doom in the browser is a minimal HTML page that is also hosted live [here](https://jacobenget.github.io/doom.wasm/examples/browser/doom.html).

Because of how simple this webpage is it's natural to want to embed it in another webpage using an `<iframe>`.  The only thorn making this difficult is the fact that the `body` of this webpage includes some whitespace around the `canvas` it contains (some of this whitespace is arbitrarily sized too, due to being defined in a user-agent stylesheet). Any user wanting to embed this page would benefit from this whitespace not existing, so the content of the embedded page is just the `canvas` and nothing more. 

# What changes are being made?

The two factors contributing to the `body` having whitespace around its contained `canvas` are addressed:
1. The `display` of the `canvas` is set to `block` instead of the default of `inline`, which tells the `body` to not add extra whitespace below the `canvas` in case there are any contained characters that have a [Descender](https://en.wikipedia.org/wiki/Descender)
   - FYI [this StackOverflow post](https://stackoverflow.com/questions/6540163/a-few-extra-pixels-of-height-where-could-they-be-coming-from) and the associated answers were what educated my on this problem and its possible solutions.
2. Any user-agent `padding` and `margin` style setting of the `body` has been removed
   - Browsers often apply a default `margin: 8px` to `body` 