### PR TITLE
Provide Details on Controlling Browser Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Providing a [WebAssembly](https://webassembly.org/) module that can fully run [_Doom_](https://en.wikipedia.org/wiki/Doom_(1993_video_game)) while having a small and easy-to-understand interface.
 
-[Here](https://jacobenget.github.io/doom.wasm/examples/browser/doom.html) is a bare-bones (i.e. the source code is very simple, take a look!) example of using this WebAssembly module to run _Doom_ in the browser.
+[Here](https://jacobenget.github.io/doom.wasm/examples/browser/doom.html) is a bare-bones (i.e. the source code is very simple, take a look!) example of using this WebAssembly module to run _Doom_ in the browser - game controls are the same keyboard controls present in vanilla _Doom_, detailed [here](https://doom.fandom.com/wiki/Controls#Default_controls).
 
 ## Why?
 

--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -10,6 +10,8 @@ Particularly, this example only manages these details in order to run _Doom_:
 1. Listen to all [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent) activity on the HTML canvas and forward all relevant ones to _Doom_
 1. Forward _Doom_ `info` and `error` messages to the JavaScript console (not necessary, but helpful!)
 
+Game controls in this example are the same keyboard controls present in vanilla _Doom_, detailed [here](https://doom.fandom.com/wiki/Controls#Default_controls).
+
 What's missing? This example doesn't support loading custom WADs into _Doom_ (instead _Doom_ always loads the [_Doom_ shareware WAD](https://doomwiki.org/wiki/DOOM1.WAD)), and doesn't support the user saving their game progress.
 
 It wouldn't be difficult to add these missing features to this example, but they're being left out so this example is a demonstration of the minimal code needed to get _Doom_ running in this use case.


### PR DESCRIPTION
# What's motivating this work?

In a few places the live browser example of running Doom via `doom.wasm` is mentioned and linked to. These links provide an easy way for any visitor to play _Doom_ and so they would benefit from giving the visitor hints on how to control the game.

# What changes are being made?

In those places we are now providing a [link](https://doom.fandom.com/wiki/Controls#Default_controls) to the keyboard controls in vanilla Doom, and mentioning that those are the same controls in this version of the game.